### PR TITLE
feat.relocation 썸네일과 텍스트 카드 위치 변경

### DIFF
--- a/webapp/src/components/jobAritcles/components/FeedCard.tsx
+++ b/webapp/src/components/jobAritcles/components/FeedCard.tsx
@@ -28,16 +28,16 @@ export const FeedCard: React.FC<FeedCardProps> = ({ articleId, title, price, reg
   return (
     <Container>
       <Button onClick={onClick}>
-        <Left>
+        <Thumbnail>
+          <LazyLoadImage src={imageUrl} effect="opacity" width={108} height={108} />
+        </Thumbnail>
+        <Right>
           <Title>{title}</Title>
           <Subtitle>
             {region} · {daysAgo} days ago
           </Subtitle>
           <Price>{price.toLocaleString()}원</Price>
-        </Left>
-        <Thumbnail>
-          <LazyLoadImage src={imageUrl} effect="opacity" width={108} height={108} />
-        </Thumbnail>
+        </Right>
       </Button>
     </Container>
   );
@@ -67,7 +67,7 @@ export const Thumbnail = styled(OverflowHidden)`
   background-position: 50% 50%;
 `;
 
-export const Left = styled(Flex1)``;
+export const Right = styled(Flex1)``;
 
 export const Title = styled.h1`
   font-size: 1rem;


### PR DESCRIPTION
# Feat. Relocation
- [x] 디자인 변경
- [x] css Component명 변경 

## 변경사항

 - 썸네일 위치와 텍스트 카드 위치 변경
 - 위치 변경으로 인해 StyledComponent명을 Left에서 Right로 변경

## 변경 화면
![image](https://github.com/user-attachments/assets/ddf12bca-d348-49e1-8086-8bd8dc555f34)
